### PR TITLE
Add a flag to specify pure go packet size

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Available probing means are:
 
 ### ping
 
-Pure go is the default option but for unprivileged users ([see linux notes](#linux-notes-on-pure-go-ping)), OS/system's ping command (usually available on OS with specific cap or setuid) can be used with a background spawn model with `-s` flag. Privileged mode (default when user is root or on windows) can be forcefully enabled with `-privileged`.
+Pure Go is the default option but for unprivileged users ([see linux notes](#linux-notes-on-pure-go-ping)), OS/system's ping command (usually available on OS with specific cap or setuid) can be used with a background spawn model with `-s` flag. Privileged mode (default when user is root or on windows) can be forcefully enabled with `-privileged`.
+
+On pure Go implementation, ICMP packet size can be specified using `-size` option. Given size doesn't account for the 28 bytes header (note for usual limits: 1472 or 8972). This has no effect on system's ping, refer to system's manual and use `-ping-options`.
 
 Hint ca be given about address family resolution using `ip<family>://`, `ip://` is the default, `ip4://` to force IPv4 and `ip6://` to force IPv6, example:
  - `google.com` is equivalent to `ip://google.com`

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ type Options struct {
 func main() {
 	options := Options{}
 	options.privileged = flag.Bool("privileged", false, "switch to privileged mode (default if run as root or on windows; ineffective with '-s')")
-	options.size = flag.Int("size", 24, "packet size")
+	options.size = flag.Int("size", 24, "pure-go ICMP packet size (without header's 28 Bytes (note: values to test common limits: 1472 or 8972))\nnot relevant for system's ping, refer to system's ping man page and ping-options option")
 	options.system = flag.Bool("s", false, "uses system's ping")
 	options.system_ping_options = flag.String("ping-options", "", "quoted options to provide to system's ping (ex: \"-Q 2\"), implies '-s', refer to system's ping man page")
 	options.quiet = flag.Bool("q", false, "quiet mode, disable live update")

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ var Builder = "go version go1.xx.y os/platform"
 type Options struct {
 	quiet               *bool
 	privileged          *bool
+	size                *int
 	system              *bool
 	log                 *string
 	update              *bool
@@ -25,6 +26,7 @@ type Options struct {
 func main() {
 	options := Options{}
 	options.privileged = flag.Bool("privileged", false, "switch to privileged mode (default if run as root or on windows; ineffective with '-s')")
+	options.size = flag.Int("size", 24, "packet size")
 	options.system = flag.Bool("s", false, "uses system's ping")
 	options.system_ping_options = flag.String("ping-options", "", "quoted options to provide to system's ping (ex: \"-Q 2\"), implies '-s', refer to system's ping man page")
 	options.quiet = flag.Bool("q", false, "quiet mode, disable live update")

--- a/pinger_probing.go
+++ b/pinger_probing.go
@@ -16,6 +16,7 @@ type ProbingWrapper struct {
 	ip         *net.IPAddr
 	hstring    string
 	pinger     *probing.Pinger
+	size       int
 	stats      *PWStats
 	privileged bool
 }
@@ -32,6 +33,8 @@ func (w *ProbingWrapper) Start() {
 	// pinger.OnSend = pingwrapper.OnRecv
 	w.pinger.OnRecv = w.onRecv
 	w.pinger.OnDuplicateRecv = w.onDuplicateRecv
+	w.pinger.Size = w.size
+	w.pinger.SetDoNotFragment(true)
 
 	if runtime.GOOS == "windows" || os.Getuid() == 0 {
 		w.pinger.SetPrivileged(true)

--- a/pingwrapper.go
+++ b/pingwrapper.go
@@ -65,6 +65,7 @@ func NewPingWrapper(host string, options Options, transition_writer *TransitionW
 			host:       host,
 			ip:         mustResolve(found_host, found_ip_family),
 			privileged: *options.privileged,
+			size:       *options.size,
 			stats:      &PWStats{transition_writer: transition_writer},
 		}
 	}


### PR DESCRIPTION
Hello @babs,

I needed to validate MTU accross multiple servers, having a packet size option in multiping was really convenient for that.

I don't know how to handle that consistently with the system ping option, since the size flag may change depending on the implementation. In consequence this should probably not be merged.

I guess a clean way of doing this would be to separate multiping into two binaries : the wrapper around the system ping and the pure go option.

Regards.